### PR TITLE
fix(docker): harden Dockerfile by disabling npm install scripts and u…

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-and-deploy:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
@@ -71,7 +72,7 @@ jobs:
         ignore-unfixed: true
 
     - name: Deploy to PROD (on main branch)
-      if: github.ref == 'refs/heads/main'
+      if: github.event.pull_request.base.ref == 'main'
       uses: appleboy/ssh-action@v1.0.3
       with:
         host: ${{ secrets.DEV_HOST }}
@@ -88,7 +89,7 @@ jobs:
       
 
     # - name: Deploy to UAT (on uat branch)
-    #   if: github.ref == 'refs/heads/uat'
+    #   if: github.event.pull_request.base.ref == 'uat'
     #   uses: appleboy/ssh-action@v1.0.3
     #   with:
     #     host: ${{ secrets.UAT_HOST }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,25 @@
-# Dockerfile
-# Base image
-FROM node:18-alpine as build
+# Stage 1: Build React app
+FROM node:18-alpine AS build
 
-# Set working directory
 WORKDIR /app
 
-# Copy source files
+# Install only with ignore-scripts for safety
 COPY ui/package*.json ./
-RUN npm install
+RUN npm install --ignore-scripts
 
 COPY ui/ ./
 RUN npm run build
 
-# Serve app with nginx
+# Stage 2: Serve with nginx as non-root
 FROM nginx:alpine
+
+# Run as non-root user
+USER nginx
+
+# Copy built files
 COPY --from=build /app/build /usr/share/nginx/html
 
-# Copy custom nginx config (optional)
+# (Optional) Secure custom nginx config
 # COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80


### PR DESCRIPTION
- Added `--ignore-scripts` to `npm install` to prevent execution of unsafe lifecycle scripts
- Switched nginx container to run as non-root `nginx` user
- Updated GitHub Actions workflow to trigger only on PR merge into main, uat, or release branches
- Added conditional deployment based on PR target branch